### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,7 +7,7 @@
 #######################################
 
 TN901	KEYWORD1
-tn901_interrupt KEYWORD1
+tn901_interrupt	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -15,20 +15,20 @@ tn901_interrupt KEYWORD1
 
 init	KEYWORD2
 read	KEYWORD2
-getEnvironmentTemperature KEYWORD2
-getObjectTemperature KEYWORD2
-startConversion KEYWORD2
-endConversion KEYWORD2
-processIsr KEYWORD2
-attachEnvironmentInterrupt KEYWORD2
-attachObjectInterrupt KEYWORD2
+getEnvironmentTemperature	KEYWORD2
+getObjectTemperature	KEYWORD2
+startConversion	KEYWORD2
+endConversion	KEYWORD2
+processIsr	KEYWORD2
+attachEnvironmentInterrupt	KEYWORD2
+attachObjectInterrupt	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-TN901_ETADDRESS LITERAL1
-TN901_OTADDRESS LITERAL1
-TN901_ENDADDRESS LITERAL1
+TN901_ETADDRESS	LITERAL1
+TN901_OTADDRESS	LITERAL1
+TN901_ENDADDRESS	LITERAL1
 MODE_ET	LITERAL1
 MODE_OT	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords