### PR TITLE
Populate the library.properties architectures field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Reading temperatures from TN9 series IR temperature sensor
 paragraph=
 category=Signal Input/Output
 url=https://github.com/Palatis/Arduino-TN9
-architectures=
+architectures=*


### PR DESCRIPTION
The previous empty architectures field caused the library's examples to appear under File > Examples > INCOMPATIBLE no matter which board is selected.